### PR TITLE
Implement common subtree elimination from diff

### DIFF
--- a/src/test/fixtures/unchanged-subtree/expected.txt
+++ b/src/test/fixtures/unchanged-subtree/expected.txt
@@ -1,0 +1,3 @@
+ \--- com.google.firebase:firebase-perf:18.0.0
+-     \--- com.squareup.okhttp3:okhttp:3.0.0 -> 4.8.0
++     \--- com.squareup.okhttp3:okhttp:3.0.0 -> 4.8.1

--- a/src/test/fixtures/unchanged-subtree/new.txt
+++ b/src/test/fixtures/unchanged-subtree/new.txt
@@ -1,0 +1,6 @@
++--- com.google.firebase:firebase-perf:18.0.0
+|    \--- com.squareup.okhttp3:okhttp:3.0.0 -> 4.8.1
+|         +--- com.squareup.okio:okio:2.7.0
+|         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
+|         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.3.72
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)

--- a/src/test/fixtures/unchanged-subtree/old.txt
+++ b/src/test/fixtures/unchanged-subtree/old.txt
@@ -1,0 +1,6 @@
++--- com.google.firebase:firebase-perf:18.0.0
+|    \--- com.squareup.okhttp3:okhttp:3.0.0 -> 4.8.0
+|         +--- com.squareup.okio:okio:2.7.0
+|         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.70 -> 1.3.72 (*)
+|         |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70 -> 1.3.72
+|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)

--- a/src/test/fixtures/version-bump-tree-only/expected.txt
+++ b/src/test/fixtures/version-bump-tree-only/expected.txt
@@ -2,9 +2,9 @@
  |    +--- com.squareup.sqldelight:runtime-jvm:1.4.0
 -|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72
 -|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
--|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
 +|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.0
 +|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
+-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
 +|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72 -> 1.4.0
 -|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 (*)
 +|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.0 (*)

--- a/src/test/fixtures/version-bump/expected.txt
+++ b/src/test/fixtures/version-bump/expected.txt
@@ -2,9 +2,9 @@
  |    +--- com.squareup.sqldelight:runtime-jvm:1.4.0
 -|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72
 -|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.3.72 (*)
--|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
 +|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.0
 +|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
+-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72
 +|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.3.72 -> 1.4.0
 -|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 (*)
 +|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72 -> 1.4.0 (*)


### PR DESCRIPTION
As a nice side-effect, this actually improves the diff for child changes as it groups together dependencies with the same coordinates.

Closes #2.