### PR TITLE
Fix task dependencies between r8Jar and fatJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ def fatJarProvider = tasks.register('fatJar', Jar) { task ->
 def r8File = new File("$buildDir/libs/$archivesBaseName-r8.jar")
 def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 	task.dependsOn(configurations.named('runtimeClasspath'))
-	task.dependsOn(fatJarProvider.get())
+	task.inputs.files(fatJarProvider.get().outputs.files)
 	task.outputs.file(r8File)
 
 	task.classpath(configurations.r8)


### PR DESCRIPTION
I noticed that after changing Kotlin source files, Gradle thought the r8Jar task was up-to-date.
This change uses the output files of the fatJar task as an input to the r8Jar task. The task dependency
can be inferred by Gradle, the input / output dependency cannot.