### PR TITLE
Upgrade Dependencies and use Path extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0'
+		classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
 	}
 }
 
@@ -11,10 +11,10 @@ configurations {
 }
 
 dependencies {
-	testImplementation 'junit:junit:4.13'
-	testImplementation 'com.google.truth:truth:1.0.1'
+	testImplementation 'junit:junit:4.13.2'
+	testImplementation 'com.google.truth:truth:1.1.3'
 
-	r8 'com.android.tools:r8:2.0.99'
+	r8 'com.android.tools:r8:3.0.73'
 }
 
 def fatJarProvider = tasks.register('fatJar', Jar) { task ->
@@ -58,7 +58,7 @@ def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 		'--lib', System.properties['java.home'].toString()
 	]
 	doFirst {
-		task.args += fatJarProvider.get().archivePath
+		task.args += fatJarProvider.get().archiveFile.get().asFile
 	}
 }
 

--- a/src/main/kotlin/com/jakewharton/gradle/dependencies/main.kt
+++ b/src/main/kotlin/com/jakewharton/gradle/dependencies/main.kt
@@ -4,9 +4,9 @@ package com.jakewharton.gradle.dependencies
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.readBytes
 import kotlin.system.exitProcess
 
 fun main(vararg args: String) {
@@ -25,8 +25,8 @@ fun main(vararg args: String) {
 	print(dependencyTreeDiff(old, new))
 }
 
-// TODO replace with https://youtrack.jetbrains.com/issue/KT-19192
 @Suppress("NOTHING_TO_INLINE")
 private inline fun Path.readText(charset: Charset = StandardCharsets.UTF_8): String {
-	return Files.readAllBytes(this).toString(charset)
+	// stdlib's Path#readText uses an input stream, which increases the binary size by around 150%
+	return readBytes().toString(charset)
 }


### PR DESCRIPTION
The project has been stuck on 1.4 for a bit, updating is probably helpful and it only uses 5 KB extra.

Also because of the higher Kotlin version the new Path extensions can be used, do note though that the default `readText` isn't optimized enough, and so a custom version was needed.