### PR TITLE
Force R8 to run on JDK 11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 	task.inputs.file(rulesFile)
 	task.outputs.file(r8File)
 
+	// R8 uses the executing JDK to determine the classfile target.
+	javaLauncher = javaToolchains.launcherFor {
+		languageVersion = JavaLanguageVersion.of(11)
+		vendor = JvmVendorSpec.AZUL
+	}
+
 	task.classpath(configurations.r8)
 	task.mainClass = 'com.android.tools.r8.R8'
 	task.args = [

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+}
+
 rootProject.name = 'dependency-tree-diff'


### PR DESCRIPTION
This should allow building with newer JDKs while still producing a JDK 11-compatible jar.