### PR TITLE
Remove sequence usage to save space in binary

### DIFF
--- a/src/main/kotlin/com/jakewharton/gradle/dependencies/treeDiff.kt
+++ b/src/main/kotlin/com/jakewharton/gradle/dependencies/treeDiff.kt
@@ -17,8 +17,10 @@ fun dependencyTreeDiff(old: String, new: String): String {
 	}
 }
 
+private val newlineRegex = "(\r\n|\n|\r)".toRegex()
+
 private fun findDependencyPaths(text: String): Set<List<String>> {
-	val dependencyLines = text.lines()
+	val dependencyLines = text.split(newlineRegex)
 		.dropWhile { !it.startsWith("+--- ") && !it.startsWith("\\---") }
 		.takeWhile { it.isNotEmpty() }
 


### PR DESCRIPTION
This shaves 40% off the final binary (35KiB --> 21KiB).