### PR TITLE
Remove unneccessary data modifier

### DIFF
--- a/src/main/kotlin/com/jakewharton/gradle/dependencies/treeDiff.kt
+++ b/src/main/kotlin/com/jakewharton/gradle/dependencies/treeDiff.kt
@@ -51,7 +51,7 @@ private fun findDependencyPaths(text: String): Set<List<String>> {
 	return dependencyPaths
 }
 
-private data class Node(
+private class Node(
 	val coordinate: String,
 	val versionInfo: String,
 	val children: MutableList<Node>,


### PR DESCRIPTION
We don't use equals, hashCode, copy, or destructuring.

Saves like 100 bytes, too!