### PR TITLE
R8: Specify the jvmTarget in rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 	r8(libs.r8) {
 		attributes {
-			// R8 needs JVM 11 but the Jar is not published with Gradle module metadata
+			// R8 needs JVM 11 but the Jar is not published with Gradle module metadata: https://issuetracker.google.com/issues/377126124
 			attribute(org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,12 @@ dependencies {
 	testImplementation libs.junit
 	testImplementation libs.assertk
 
-	r8 libs.r8
+	r8(libs.r8) {
+		attributes {
+			// R8 needs JVM 11 but the Jar is not published with Gradle module metadata
+			attribute(org.gradle.api.attributes.java.TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
+		}
+	}
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -68,12 +73,6 @@ def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 	task.inputs.file(fatJarFile)
 	task.inputs.file(rulesFile)
 	task.outputs.file(r8File)
-
-	// R8 uses the executing JDK to determine the classfile target.
-	javaLauncher = javaToolchains.launcherFor {
-		languageVersion = JavaLanguageVersion.of(11)
-		vendor = JvmVendorSpec.AZUL
-	}
 
 	task.classpath(configurations.r8)
 	task.mainClass = 'com.android.tools.r8.R8'

--- a/src/main/rules.txt
+++ b/src/main/rules.txt
@@ -1,6 +1,7 @@
 -dontobfuscate
 -allowaccessmodification
 -keepattributes SourceFile, LineNumberTable
+-target 11
 
 -keep class com.jakewharton.gradle.dependencies.DependencyTreeDiff {
 	public static void main(java.lang.String[]);


### PR DESCRIPTION
I configured R8 for another library and found the target option, so on the one hand we can remove the java toolchain (and use 21 to run R8), but on the other hand, we pass the 21 java.home as the lib option (that should ideally match and does require the toolchain again).

So what do you think?