### PR TITLE
Downgrade R8 and test binary jar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build
+      - run: build/dependency-tree-diff.jar --help
 
       - uses: actions/upload-artifact@v4
         with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [libraries]
 junit = "junit:junit:4.13.2"
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
-r8 = "com.android.tools:r8:8.9.35"
+r8 = "com.android.tools:r8:8.7.18"
 kotlin-gradle-plugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0"


### PR DESCRIPTION
R8 8.8.18 breaks the jar (by removing the manifest).